### PR TITLE
Define the binary as actual binary for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,6 @@
 			"homepage": "https://github.com/cytopia",
 			"role": "Developer"
 		}
-	]
+	],
+	"bin": ["bin/ffscreencast"]
 }


### PR DESCRIPTION
Hello, your project is pretty fun (well, there's no php inside) and may actually be useful ! But there's some things to change. Here is one of them.

This change will make composer create a link to binary folder. For now installations are not useful because of that fact.

Please notice that you need to create a new tag to make it available ;) .