### PR TITLE
Fix x11grab detection for newer ffmpeg versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ Version 0.7 (unreleased)
 -----------
 
 
-Version 0.6.3
+Version 0.6.4
+-------------
+
+- [Fix] Linux: x11grab check for newer and older versions
+
+-Version 0.6.3
 -------------
 
 - [Enh] Video to gif converter (see [contrib](contrib/))

--- a/bin/ffscreencast
+++ b/bin/ffscreencast
@@ -421,7 +421,7 @@ can_use_ffmpeg() {
 				return "${EXIT_OK}"
 			fi
 		elif [ "${UNAME}" = "Linux" ]; then
-			if ! ${FFMPEG} -version 2>&1 | $GREP '\-\-enable-x11grabsd' > /dev/null 2>&1 \
+			if ! ${FFMPEG} -version 2>&1 | $GREP '\-\-enable-x11grab' > /dev/null 2>&1 \
 				&& ! ${FFMPEG} -devices 2>&1 | $GREP 'x11grab' > /dev/null 2>&1; then
 				# Nope, no x11grab found in ffmpeg
 				return "${EXIT_ERR}"

--- a/bin/ffscreencast
+++ b/bin/ffscreencast
@@ -421,7 +421,8 @@ can_use_ffmpeg() {
 				return "${EXIT_OK}"
 			fi
 		elif [ "${UNAME}" = "Linux" ]; then
-			if ! ${FFMPEG} -devices 2>&1 | $GREP 'x11grab' > /dev/null 2>&1; then
+			if ! ${FFMPEG} -version 2>&1 | $GREP '\-\-enable-x11grabsd' > /dev/null 2>&1 \
+				&& ! ${FFMPEG} -devices 2>&1 | $GREP 'x11grab' > /dev/null 2>&1; then
 				# Nope, no x11grab found in ffmpeg
 				return "${EXIT_ERR}"
 			else

--- a/bin/ffscreencast
+++ b/bin/ffscreencast
@@ -421,7 +421,7 @@ can_use_ffmpeg() {
 				return "${EXIT_OK}"
 			fi
 		elif [ "${UNAME}" = "Linux" ]; then
-			if ! ${FFMPEG} -version 2>&1 | $GREP '\-\-enable-x11grab' > /dev/null 2>&1; then
+			if ! ${FFMPEG} -devices 2>&1 | $GREP 'x11grab' > /dev/null 2>&1; then
 				# Nope, no x11grab found in ffmpeg
 				return "${EXIT_ERR}"
 			else

--- a/bin/ffscreencast
+++ b/bin/ffscreencast
@@ -19,7 +19,7 @@ INFO_AUTHOR="Patrick Plocke <patrick@plocke.de>"
 INFO_GPGKEY="0x28BF179F"
 INFO_DATE="2017-03-18"
 INFO_LICENSE="MIT"
-INFO_VERSION="0.6.3"
+INFO_VERSION="0.6.4"
 INFO_NAME="ffscreencast"
 
 


### PR DESCRIPTION
Newer ffmpeg versions use libxcb for capture and not the old xlib
method.  In this case the --enable-x11grab option is not used and the
detection code fails.  We check the 'ffmpeg -devices' output for x11grab
to verify support instead.